### PR TITLE
CU Boulder User Invite v1.1

### DIFF
--- a/config/install/ucb_user_invite.settings.yml
+++ b/config/install/ucb_user_invite.settings.yml
@@ -1,4 +1,4 @@
-roles: []
+roles: {  }
 default_role: ''
 
 default_custom_message: 'Hello,'
@@ -11,7 +11,7 @@ invite_template: |
 
   To accept this invitation:
   1) Go to %login_link%
-  2) Log in with your CU Boulder credentials.
+  2) Log in with your credentials.
 
   This invitation was sent by a manager of the site with permission to invite users. If you have any questions, please reach out to them directly at [current-user:mail].
 

--- a/config/install/ucb_user_invite.settings.yml
+++ b/config/install/ucb_user_invite.settings.yml
@@ -1,5 +1,4 @@
 roles: {  }
-default_role: ''
 
 default_custom_message: 'Hello,'
 

--- a/src/Form/InviteForm.php
+++ b/src/Form/InviteForm.php
@@ -88,7 +88,7 @@ class InviteForm extends FormBase {
       '#type' => 'textarea',
       '#cols' => 40,
       '#rows' => 5,
-      '#description' => $this->t('Optionally add a custom message before the standard template. Tokens are supported.'),
+      '#description' => $this->t('Optionally add a custom message before the standard template. Can be left blank. Tokens are supported.'),
       '#default_value' => $config->get('default_custom_message'),
     ];
     $form['submit'] = [

--- a/src/Form/InviteForm.php
+++ b/src/Form/InviteForm.php
@@ -88,7 +88,7 @@ class InviteForm extends FormBase {
       '#type' => 'textarea',
       '#cols' => 40,
       '#rows' => 5,
-      '#description' => $this->t('The custom message will be included before the standard template. Tokens are supported.'),
+      '#description' => $this->t('Optionally add a custom message before the standard template. Tokens are supported.'),
       '#default_value' => $config->get('default_custom_message'),
     ];
     $form['submit'] = [

--- a/src/Form/InviteForm.php
+++ b/src/Form/InviteForm.php
@@ -98,8 +98,6 @@ class InviteForm extends FormBase {
 
     if (empty($roles)) {
       $this->messenger()->addError($this->t('Your site is not yet configured to invite users. Contact the site administrator to <a href="@adminlink">configure the invite feature</a>.', ['@adminlink' => $this->helper->getAdminFormLink()]));
-      $form['rid']['#options'] = ['' => '(no roles avaliable)'];
-      $form['rid']['#disabled'] = TRUE;
       $form['email']['#disabled'] = TRUE;
       $form['custom_message']['#disabled'] = TRUE;
       $form['submit']['#disabled'] = TRUE;
@@ -115,8 +113,6 @@ class InviteForm extends FormBase {
    * {@inheritdoc}
    */
   public function validateForm(array &$form, FormStateInterface $form_state) {
-    parent::validateForm($form, $form_state);
-
     $rids = array_filter($form_state->getStorage()['rids'], function ($rid) use ($form_state) {
       return $form_state->getValue('role_' . $rid . '_enabled');
     });
@@ -129,7 +125,7 @@ class InviteForm extends FormBase {
     $invitedUsers = preg_split("/[,\s+]/", $form_state->getValue('identikeys'), -1, PREG_SPLIT_NO_EMPTY);
     foreach ($invitedUsers as $invitedUser) {
       if (!$this->helper->isCuBoulderIdentiKeyValid($invitedUser)) {
-        $form_state->setErrorByName('identikeys', $this->t('Invalid CU Boulder IdentiKey: @value', ['@value' => $invitedUser]));
+        $form_state->setErrorByName('identikeys', $this->t('Invalid IdentiKey: @value', ['@value' => $invitedUser]));
       }
     }
     $form_state->setValue('invited_users', $invitedUsers);

--- a/src/Form/InviteForm.php
+++ b/src/Form/InviteForm.php
@@ -78,9 +78,9 @@ class InviteForm extends FormBase {
       ];
     }
     $form['identikeys'] = [
-      '#title' => $this->t('CU Boulder User IdentiKeys'),
+      '#title' => $this->t('User IdentiKeys'),
       '#type' => 'textfield',
-      '#description' => $this->t('Comma-separated list of users that are invited and granted the above role.'),
+      '#description' => $this->t('Comma-separated list of <a target="_blank" href="@identikey_about_link">IdentiKeys</a> for users to be invited and given the selected roles. The users will be able to securely log in using their CU Boulder-provided credentials. Don\'t include "@colorado.edu" after the IdentiKeys.', ['@identikey_about_link' => 'https://oit.colorado.edu/services/identity-access-management/identikey']),
       '#required' => TRUE,
     ];
     $form['custom_message'] = [

--- a/src/Form/InviteForm.php
+++ b/src/Form/InviteForm.php
@@ -61,10 +61,10 @@ class InviteForm extends FormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config($this->helper->getConfigName());
 
+    // Define roles that users can have.
     $roles = $this->helper->getAllowedRoles();
-    $defaultCustomMessage = $config->get('default_custom_message');
-    $form_state->setStorage(['rids' => array_keys($roles), 'default_custom_message' => $defaultCustomMessage]);
 
+    $form_state->setStorage(['rids' => array_keys($roles)]);
     $form['roles'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('Roles'),
@@ -89,7 +89,7 @@ class InviteForm extends FormBase {
       '#cols' => 40,
       '#rows' => 5,
       '#description' => $this->t('The custom message will be included before the standard template. Tokens are supported.'),
-      '#placeholder' => $defaultCustomMessage,
+      '#default_value' => $config->get('default_custom_message'),
     ];
     $form['submit'] = [
       '#type' => 'submit',
@@ -113,8 +113,7 @@ class InviteForm extends FormBase {
    * {@inheritdoc}
    */
   public function validateForm(array &$form, FormStateInterface $form_state) {
-    $storage = $form_state->getStorage();
-    $rids = array_filter($storage['rids'], function ($rid) use ($form_state) {
+    $rids = array_filter($form_state->getStorage()['rids'], function ($rid) use ($form_state) {
       return $form_state->getValue('role_' . $rid . '_enabled');
     });
     if (empty($rids)) {
@@ -130,8 +129,6 @@ class InviteForm extends FormBase {
       }
     }
     $form_state->setValue('invited_users', $invitedUsers);
-    $customMessage = $form_state->getValue('custom_message');
-    $form_state->setValue('custom_message', $customMessage ? $customMessage : $storage['default_custom_message']);
   }
 
   /**

--- a/src/Form/InviteForm.php
+++ b/src/Form/InviteForm.php
@@ -61,10 +61,10 @@ class InviteForm extends FormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config($this->helper->getConfigName());
 
-    // Define roles that users can have.
     $roles = $this->helper->getAllowedRoles();
+    $defaultCustomMessage = $config->get('default_custom_message');
+    $form_state->setStorage(['rids' => array_keys($roles), 'default_custom_message' => $defaultCustomMessage]);
 
-    $form_state->setStorage(['rids' => array_keys($roles)]);
     $form['roles'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('Roles'),
@@ -89,7 +89,7 @@ class InviteForm extends FormBase {
       '#cols' => 40,
       '#rows' => 5,
       '#description' => $this->t('The custom message will be included before the standard template. Tokens are supported.'),
-      '#default_value' => $config->get('default_custom_message'),
+      '#placeholder' => $defaultCustomMessage,
     ];
     $form['submit'] = [
       '#type' => 'submit',
@@ -113,7 +113,8 @@ class InviteForm extends FormBase {
    * {@inheritdoc}
    */
   public function validateForm(array &$form, FormStateInterface $form_state) {
-    $rids = array_filter($form_state->getStorage()['rids'], function ($rid) use ($form_state) {
+    $storage = $form_state->getStorage();
+    $rids = array_filter($storage['rids'], function ($rid) use ($form_state) {
       return $form_state->getValue('role_' . $rid . '_enabled');
     });
     if (empty($rids)) {
@@ -129,6 +130,8 @@ class InviteForm extends FormBase {
       }
     }
     $form_state->setValue('invited_users', $invitedUsers);
+    $customMessage = $form_state->getValue('custom_message');
+    $form_state->setValue('custom_message', $customMessage ? $customMessage : $storage['default_custom_message']);
   }
 
   /**

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -80,11 +80,13 @@ class SettingsForm extends ConfigFormBase {
       $form['role_' . $rid]['role_' . $rid . '_enabled'] = [
         '#type' => 'checkbox',
         '#title' => $this->t('Allow users to be invited to join this role'),
+        '#description' => $this->t('Anyone with permission to send user invites will be able to assign this role. Grant with caution!'),
         '#default_value' => isset($roleSettings[$rid]['status']) && $roleSettings[$rid]['status'],
       ];
       $form['role_' . $rid]['role_' . $rid . '_default'] = [
         '#type' => 'checkbox',
-        '#title' => $this->t('Select this role by default when sending an invite'),
+        '#title' => $this->t('Select this role by default'),
+        '#description' => $this->t('This role will be selected by default when sending an invite. Recommended for the most common roles on the site.'),
         '#default_value' => isset($roleSettings[$rid]['default']) && $roleSettings[$rid]['default'],
         '#states' => [
           'visible' => [
@@ -163,7 +165,7 @@ class SettingsForm extends ConfigFormBase {
     foreach ($rids as $rid) {
       $roles[$rid] = [
         'status' => (bool) $form_state->getValue('role_' . $rid . '_enabled'),
-        'default' => $form_state->getValue('role_' . $rid . '_default'),
+        'default' => (bool) $form_state->getValue('role_' . $rid . '_default'),
         'description' => $form_state->getValue('role_' . $rid . '_description'),
       ];
       if ($form_state->getValue('role_' . $rid . '_default')) {

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -68,21 +68,31 @@ class SettingsForm extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config($this->helper->getConfigName());
 
-    $roles = $this->helper->getAllRoleNames();
+    $roleLabels = $this->helper->getAllRoleLabels();
     $roleSettings = $config->get('roles') ?? [];
 
-    $form_state->setStorage(['rids' => array_keys($roles)]);
-    $form['roles'] = [
-      '#type' => 'fieldset',
-      '#title' => $this->t('Roles users can be invited to join'),
-    ];
-    foreach ($roles as $rid => $roleName) {
-      $form['roles'][$rid . '_enabled'] = [
+    $form_state->setStorage(['rids' => array_keys($roleLabels)]);
+    foreach ($roleLabels as $rid => $roleLabel) {
+      $form['role_' . $rid] = [
+        '#type' => 'fieldset',
+        '#title' => $roleLabel,
+      ];
+      $form['role_' . $rid]['role_' . $rid . '_enabled'] = [
         '#type' => 'checkbox',
-        '#title' => $roleName,
+        '#title' => $this->t('Allow users to be invited to join this role'),
         '#default_value' => isset($roleSettings[$rid]['status']) && $roleSettings[$rid]['status'],
       ];
-      $form['roles'][$rid . '_description'] = [
+      $form['role_' . $rid]['role_' . $rid . '_default'] = [
+        '#type' => 'checkbox',
+        '#title' => $this->t('Select this role by default when sending an invite'),
+        '#default_value' => isset($roleSettings[$rid]['default']) && $roleSettings[$rid]['default'],
+        '#states' => [
+          'visible' => [
+            ':input[name="role_' . $rid . '_enabled"]' => ['checked' => TRUE],
+          ],
+        ],
+      ];
+      $form['role_' . $rid]['role_' . $rid . '_description'] = [
         '#type' => 'textfield',
         '#title' => $this->t('Role description'),
         '#description' => $this->t('Optionally set a description for this role to appear when sending an invite.'),
@@ -90,20 +100,11 @@ class SettingsForm extends ConfigFormBase {
         '#maxlength' => 1024,
         '#states' => [
           'visible' => [
-            ':input[name="' . $rid . '_enabled"]' => ['checked' => TRUE],
+            ':input[name="role_' . $rid . '_enabled"]' => ['checked' => TRUE],
           ],
         ],
       ];
     }
-
-    $form['default_role'] = [
-      '#title' => $this->t('Default role'),
-      '#description' => $this->t('Choose the default role you wish to have selected on the invite page.'),
-      '#type' => 'radios',
-      '#options' => $roles,
-      '#default_value' => $config->get('default_role') ?? '',
-      '#required' => TRUE,
-    ];
 
     $form['default_custom_message'] = [
       '#title' => $this->t('Default custom message'),
@@ -158,23 +159,18 @@ class SettingsForm extends ConfigFormBase {
 
     $rids = $form_state->getStorage()['rids'];
     $roles = [];
-    $defaultRole = $form_state->getValue('default_role');
-    $defaultRoleValid = FALSE;
+    $defaultRoles = [];
     foreach ($rids as $rid) {
       $roles[$rid] = [
-        'status' => (bool) $form_state->getValue($rid . '_enabled'),
-        'description' => $form_state->getValue($rid . '_description'),
+        'status' => (bool) $form_state->getValue('role_' . $rid . '_enabled'),
+        'default' => $form_state->getValue('role_' . $rid . '_default'),
+        'description' => $form_state->getValue('role_' . $rid . '_description'),
       ];
-      if ($rid == $defaultRole && $roles[$rid]['status']) {
-        $defaultRoleValid = TRUE;
+      if ($form_state->getValue('role_' . $rid . '_default')) {
+        $defaultRoles[] = $rid;
       }
     }
     $form_state->setValue('roles', $roles);
-
-    if (!$defaultRoleValid) {
-      $form_state->setErrorByName('default_role', $this->t('Default role can only be one of the roles selected to invite.'));
-      return;
-    }
   }
 
   /**
@@ -183,7 +179,6 @@ class SettingsForm extends ConfigFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->config($this->helper->getConfigName())
       ->set('roles', $form_state->getValue('roles'))
-      ->set('default_role', $form_state->getValue('default_role'))
       ->set('default_custom_message', $form_state->getValue('default_custom_message'))
       ->set('invite_subject', $form_state->getValue('invite_subject'))
       ->set('invite_template', $form_state->getValue('invite_template'))

--- a/src/UserInviteHelperService.php
+++ b/src/UserInviteHelperService.php
@@ -69,7 +69,9 @@ class UserInviteHelperService {
   protected $mailManager;
 
   /**
-   * The entity type manager, used in the process of checking for an existing user account.
+   * The entity type manager.
+   *
+   * Used in the process of checking for an existing user account.
    *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
@@ -77,7 +79,9 @@ class UserInviteHelperService {
 
 
   /**
-   * The entity type repository, used in the process of checking for an existing user account.
+   * The entity type repository.
+   *
+   * Used in the process of checking for an existing user account.
    *
    * @var \Drupal\Core\Entity\EntityTypeRepositoryInterface
    */
@@ -101,9 +105,9 @@ class UserInviteHelperService {
    * @param \Drupal\Core\Mail\MailManagerInterface $mailManager
    *   The mail manager used for sending emails.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
-   *   The entity type manager, used in the process of checking for an existing user account.
+   *   The entity type manager.
    * @param \Drupal\Core\Entity\EntityTypeRepositoryInterface $entityTypeRepository
-   *   The entity type repository, used in the process of checking for an existing user account.
+   *   The entity type repository.
    */
   public function __construct(
     AccountInterface $user,
@@ -153,32 +157,38 @@ class UserInviteHelperService {
    * @return array
    *   id -> label mapping of all roles for invites.
    */
-  public function getAllRoleNames() {
+  public function getAllRoleLabels() {
     // Load all user role entites.
-    $userRoles = Role::loadMultiple();
+    $userRoles = $this->entityTypeManager->getStorage($this->entityTypeRepository->getEntityTypeFromClass(Role::class))->loadMultiple();
     // Remove the anonymous role.
     unset($userRoles[Role::ANONYMOUS_ID]);
     return array_map(
-      function (Role $roleEntity) {
-        // Convert the role entity to a string.
-        return $roleEntity->label();
-      }, $userRoles);
+    function (Role $roleEntity) {
+      // Convert the role entity to a string.
+      return $roleEntity->label();
+    }, $userRoles);
   }
 
   /**
-   * Gets the allowed role names.
+   * Gets the allowed roles.
    *
    * @return array
-   *   id -> label mapping of only allowed roles for invites.
+   *   id -> label, description mapping of only allowed roles for invites.
    */
-  public function getAllowedRoleNames() {
-    $userRoleNames = $this->getAllRoleNames();
-    $roles = $this->getConfig()->get('roles') ?? [];
-    return array_filter($userRoleNames,
-      function ($rid) use ($roles) {
-        // Filter roles that are not allowed.
-        return isset($roles[$rid]['status']) && $roles[$rid]['status'];
-      }, ARRAY_FILTER_USE_KEY);
+  public function getAllowedRoles() {
+    $roleSettings = $this->getConfig()->get('roles') ?? [];
+    $roleLabels = $this->getAllRoleLabels();
+    $allowedRoles = [];
+    foreach ($roleLabels as $rid => $roleLabel) {
+      if (isset($roleSettings[$rid]['status']) && $roleSettings[$rid]['status']) {
+        $allowedRoles[$rid] = [
+          'label' => $roleLabel,
+          'default' => $roleSettings[$rid]['default'] ?? FALSE,
+          'description' => $roleSettings[$rid]['description'] ?? '',
+        ];
+      }
+    }
+    return $allowedRoles;
   }
 
   /**
@@ -232,25 +242,32 @@ class UserInviteHelperService {
   }
 
   /**
-   * Emails CU Boulder users inviting them to log in to the site, and grants their accounts a role.
+   * Sends user invites.
+   *
+   * Emails users inviting them to log in to the site, and grants their
+   * accounts a role.
    *
    * @param string[] $invitedUsers
    *   An array of CU Boulder IdentiKeys.
-   * @param string $roleId
-   *   The role to grant. Must be the id of a Role entity.
+   * @param string[] $rids
+   *   The roles to grant. Must be an array of Role entity ids.
    * @param string $customMessage
    *   A custom message to include in the invite email.
    * @param bool $mailConfirmation
-   *   Whether to mail a confirmation back to the sender in addition to sending the invites. Defaults to TRUE.
+   *   Whether to mail a confirmation back to the sender in addition to sending
+   *   the invites. Defaults to TRUE.
    */
-  public function invite(array $invitedUsers, $roleId, $customMessage, $mailConfirmation = TRUE) {
-    $role = Role::load($roleId);
+  public function invite(array $invitedUsers, $rids, $customMessage, $mailConfirmation = TRUE) {
+    $roles = $this->entityTypeManager->getStorage($this->entityTypeRepository->getEntityTypeFromClass(Role::class))->loadMultiple($rids);
     // Data to pass to the email message template.
     $data = [
       'config_name' => $this->getConfigName(),
-      // 'invite_role' => $role,
-      'invite_role_label' => $role->label(),
-      'invite_role_id' => $role->id(),
+      'invite_role_label' => implode(', ', array_map(function ($role) {
+        return $role->label();
+      }, $roles)),
+      'invite_role_id' => implode(', ', array_map(function ($role) {
+        return $role->id();
+      }, $roles)),
       'invite_custom_message' => $customMessage,
       'invite_user_list' => $invitedUsers,
       'invite_address_list' => array_map(
@@ -261,17 +278,19 @@ class UserInviteHelperService {
     $senderEmail = $this->user->getEmail();
     foreach ($invitedUsers as $invitedUser) {
       $invitedAddress = $this->cuBoulderIdentiKeyToEmail($invitedUser);
-      // Mail the invite. Reply-To will be set to the email of the user sending the invite.
+      // Mail the invite. Reply-To will be set to the email of the user sending
+      // the invite.
       $output = $this->mailManager->mail('ucb_user_invite', 'invite', $invitedAddress, $this->user->getPreferredAdminLangcode(), $data, $senderEmail);
       if ($output['result']) {
         $this->messenger->addStatus('Invite sent to ' . $invitedAddress . '!');
-        $this->createAccount($invitedUser, $invitedAddress, $roleId);
+        $this->createAccount($invitedUser, $invitedAddress, $rids);
       }
       else {
         $this->messenger->addError('Invite to ' . $invitedAddress . ' failed!');
       }
     }
-    // Mail the confirmation back to the sender. Reply-To will be set to the administration email of the site.
+    // Mail the confirmation back to the sender. Reply-To will be set to the
+    // administration email of the site.
     if ($mailConfirmation) {
       $administratorEmail = $this->configFactory->get('system.site')->get('mail');
       $this->mailManager->mail('ucb_user_invite', 'confirmation', $senderEmail, $this->user->getPreferredAdminLangcode(), $data, $administratorEmail);
@@ -285,18 +304,20 @@ class UserInviteHelperService {
    *   The unique username.
    * @param string $invitedAddress
    *   The email address of the user.
-   * @param string $roleId
-   *   The role to grant. Must be the id of a Role entity.
+   * @param string[] $rids
+   *   The roles to grant. Must be an array of Role entity ids.
    */
-  protected function createAccount($invitedUser, $invitedAddress, $roleId) {
+  protected function createAccount($invitedUser, $invitedAddress, $rids) {
     $storage = $this->entityTypeManager->getStorage($this->entityTypeRepository->getEntityTypeFromClass(User::class));
     // Comes back as an array but there should be only one.
     $existingUserIds = $storage->getQuery()->accessCheck(FALSE)->condition('name', $invitedUser)->execute();
-    if ($existingUserIds) {
-      $existingUser = User::load(array_keys($existingUserIds)[0]);
+    /** @var \Drupal\user\UserInterface|null $existingUser */
+    if ($existingUserIds && ($existingUser = $storage->load(array_keys($existingUserIds)[0]))) {
       // Trying to add `authenticated` role results in error, this avoids it.
-      if ($roleId != Role::AUTHENTICATED_ID) {
-        $existingUser->addRole($roleId);
+      foreach ($rids as $rid) {
+        if ($rid != Role::AUTHENTICATED_ID) {
+          $existingUser->addRole($rid);
+        }
       }
       $existingUser->save();
     }
@@ -307,7 +328,7 @@ class UserInviteHelperService {
         // This password isn't used to login, SSO is used instead.
         'pass' => 'password',
         'status' => 1,
-        'roles' => $roleId,
+        'roles' => $rids,
       ])->enforceIsNew()->save();
     }
   }

--- a/src/UserInviteHelperService.php
+++ b/src/UserInviteHelperService.php
@@ -128,20 +128,20 @@ class UserInviteHelperService {
   }
 
   /**
-   * Gets the machine name of the CU Boulder User Invite configuration.
+   * Gets the machine name of the CU Boulder User Invite settings.
    *
    * @return string
-   *   The machine name of the CU Boulder User Invite configuration.
+   *   The machine name of the CU Boulder User Invite settings.
    */
   public function getConfigName() {
-    return 'ucb_user_invite.configuration';
+    return 'ucb_user_invite.settings';
   }
 
   /**
-   * Gets the CU Boulder User Invite configuration.
+   * Gets the CU Boulder User Invite settings.
    *
    * @return \Drupal\Core\Config\Config
-   *   The read-only CU Boulder User Invite configuration, to be used locally.
+   *   The read-only CU Boulder User Invite settings, to be used locally.
    */
   protected function getConfig() {
     return $this->configFactory->get($this->getConfigName());
@@ -173,11 +173,11 @@ class UserInviteHelperService {
    */
   public function getAllowedRoleNames() {
     $userRoleNames = $this->getAllRoleNames();
-    $allowedRoleIds = $this->getConfig()->get('roles') ?? [];
+    $roles = $this->getConfig()->get('roles') ?? [];
     return array_filter($userRoleNames,
-      function ($userRoleId) use ($allowedRoleIds) {
+      function ($rid) use ($roles) {
         // Filter roles that are not allowed.
-        return isset($allowedRoleIds[$userRoleId]);
+        return isset($roles[$rid]['status']) && $roles[$rid]['status'];
       }, ARRAY_FILTER_USE_KEY);
   }
 
@@ -185,7 +185,7 @@ class UserInviteHelperService {
    * Gets the link to the administration form.
    *
    * @return string
-   *   The URL path to the configuration settings form for CU Boulder User Invite.
+   *   The URL path to the settings form for CU Boulder User Invite.
    */
   public function getAdminFormLink() {
     return $this->urlGenerator->generateFromRoute('ucb_user_invite.settings_form');

--- a/ucb_user_invite.info.yml
+++ b/ucb_user_invite.info.yml
@@ -2,7 +2,7 @@ name: CU Boulder User Invite
 description: 'Allows users with permissions to invite any CU Boulder user to log in to the site with a custom role.'
 core_version_requirement: '^9.5 || ^10'
 type: module
-version: '1.0.1'
+version: '1.1'
 package: CU Boulder
 dependencies:
   - user

--- a/ucb_user_invite.install
+++ b/ucb_user_invite.install
@@ -12,25 +12,27 @@
  */
 function ucb_user_invite_update_9501() {
   $oldSettings = \Drupal::configFactory()->getEditable('ucb_user_invite.configuration');
-  $defaultRole = $oldSettings->get('default_role');
   $newSettings = \Drupal::configFactory()->getEditable('ucb_user_invite.settings');
-  $roles = $oldSettings->get('roles');
-  $roleSettings = [];
-  foreach ($roles as $rid => $value) {
-    if ($value) {
-      $roleSettings[$rid] = [
-        'status' => TRUE,
-        'default' => $defaultRole == $rid,
-        'description' => '',
-      ];
+  if (empty($newSettings->get())) {
+    $defaultRole = $oldSettings->get('default_role');
+    $roles = $oldSettings->get('roles');
+    $roleSettings = [];
+    foreach ($roles as $rid => $value) {
+      if ($value) {
+        $roleSettings[$rid] = [
+          'status' => TRUE,
+          'default' => $defaultRole == $rid,
+          'description' => '',
+        ];
+      }
     }
+    $newSettings->set('roles', $roleSettings)
+      ->set('default_custom_message', $oldSettings->get('default_custom_message'))
+      ->set('invite_subject', $oldSettings->get('invite_subject'))
+      ->set('invite_template', $oldSettings->get('invite_template'))
+      ->set('confirmation_subject', $oldSettings->get('confirmation_subject'))
+      ->set('confirmation_template', $oldSettings->get('confirmation_template'))
+      ->save();
   }
-  $newSettings->set('roles', $roleSettings)
-    ->set('default_custom_message', $oldSettings->get('default_custom_message'))
-    ->set('invite_subject', $oldSettings->get('invite_subject'))
-    ->set('invite_template', $oldSettings->get('invite_template'))
-    ->set('confirmation_subject', $oldSettings->get('confirmation_subject'))
-    ->set('confirmation_template', $oldSettings->get('confirmation_template'))
-    ->save();
   $oldSettings->delete();
 }

--- a/ucb_user_invite.install
+++ b/ucb_user_invite.install
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @file
+ * Contains update hooks used by the CU Boulder User Invite module.
+ */
+
+/**
+ * Updates settings namespace.
+ *
+ * Introduced in version 1.1 to address ucb_user_invite#6.
+ */
+function ucb_user_invite_update_9501() {
+  $oldSettings = \Drupal::configFactory()->getEditable('ucb_user_invite.configuration');
+  $newSettings = \Drupal::configFactory()->getEditable('ucb_user_invite.settings');
+  $roles = $oldSettings->get('roles');
+  $roleSettings = [];
+  foreach ($roles as $role => $value) {
+    if ($value) {
+      $roleSettings[$role] = [
+        'status' => TRUE,
+        'description' => '',
+      ];
+    }
+  }
+  $newSettings->set('roles', $roleSettings)
+    ->set('default_role', $oldSettings->get('default_role'))
+    ->set('default_custom_message', $oldSettings->get('default_custom_message'))
+    ->set('invite_subject', $oldSettings->get('invite_subject'))
+    ->set('invite_template', $oldSettings->get('invite_template'))
+    ->set('confirmation_subject', $oldSettings->get('confirmation_subject'))
+    ->set('confirmation_template', $oldSettings->get('confirmation_template'))
+    ->save();
+  $oldSettings->delete();
+}

--- a/ucb_user_invite.install
+++ b/ucb_user_invite.install
@@ -12,19 +12,20 @@
  */
 function ucb_user_invite_update_9501() {
   $oldSettings = \Drupal::configFactory()->getEditable('ucb_user_invite.configuration');
+  $defaultRole = $oldSettings->get('default_role');
   $newSettings = \Drupal::configFactory()->getEditable('ucb_user_invite.settings');
   $roles = $oldSettings->get('roles');
   $roleSettings = [];
-  foreach ($roles as $role => $value) {
+  foreach ($roles as $rid => $value) {
     if ($value) {
-      $roleSettings[$role] = [
+      $roleSettings[$rid] = [
         'status' => TRUE,
+        'default' => $defaultRole == $rid,
         'description' => '',
       ];
     }
   }
   $newSettings->set('roles', $roleSettings)
-    ->set('default_role', $oldSettings->get('default_role'))
     ->set('default_custom_message', $oldSettings->get('default_custom_message'))
     ->set('invite_subject', $oldSettings->get('invite_subject'))
     ->set('invite_template', $oldSettings->get('invite_template'))

--- a/ucb_user_invite.module
+++ b/ucb_user_invite.module
@@ -23,8 +23,8 @@ function ucb_user_invite_mail($key, &$message, $params) {
       '%role_label%' => $params['invite_role_label'],
       '%role_id%' => $params['invite_role_id'],
       '%custom_message%' => $params['invite_custom_message'],
-      '%user_list%' => join(', ', $params['invite_user_list'] ?? []),
-      '%address_list%' => join("\n", $params['invite_address_list'] ?? []),
+      '%user_list%' => implode(', ', $params['invite_user_list'] ?? []),
+      '%address_list%' => implode("\n", $params['invite_address_list'] ?? []),
       '%login_link%' => Url::fromUserInput('/user/login', ['absolute' => TRUE])->toString(),
     ];
     $message['subject'] = $tokenService->replace(strtr($config->get($key . '_subject') ?? '', $variables), $tokens, $options);


### PR DESCRIPTION
This update:
- [New] Enables selection of multiple user roles for an invite. Previously only one role could be selected.
- [New] Adds role descriptions, which can be edited in settings.
- [Change] Updates the description for the _User IdentiKeys_ and _Custom message_ fields.
- [Change] Changes the namespace of the CU Boulder User Invite settings.

Update hook `ucb_user_invite_update_9501`:
- Migrates the settings from the old namespace to the new one.

Resolves CuBoulder/ucb_user_invite#6

Sister PR in: [tiamat10-profile](https://github.com/CuBoulder/tiamat10-profile/pull/103)