### PR TITLE
Adds markup support to email messages

### DIFF
--- a/ucb_user_invite.info.yml
+++ b/ucb_user_invite.info.yml
@@ -2,7 +2,7 @@ name: CU Boulder User Invite
 description: 'Allows users with permissions to invite any CU Boulder user to log in to the site with a custom role.'
 core_version_requirement: '^9.5 || ^10'
 type: module
-version: '1.1'
+version: '1.2'
 package: CU Boulder
 dependencies:
   - user

--- a/ucb_user_invite.module
+++ b/ucb_user_invite.module
@@ -28,6 +28,6 @@ function ucb_user_invite_mail($key, &$message, $params) {
       '%login_link%' => Url::fromUserInput('/user/login', ['absolute' => TRUE])->toString(),
     ];
     $message['subject'] = $tokenService->replace(strtr($config->get($key . '_subject') ?? '', $variables), $tokens, $options);
-    $message['body'][] = $tokenService->replace(strtr($template, $variables), $tokens, $options);
+    $message['body'] = ['#markup' => $tokenService->replace(strtr($template, $variables), $tokens, $options)];
   }
 }


### PR DESCRIPTION
[Change] This update adds email message markup support to the user invite module.

Resolves CuBoulder/ucb_user_invite#8

Sister PR in: [tiamat10-profile](https://github.com/CuBoulder/tiamat10-profile/pull/134)