### PR TITLE
Adding IdentiKey field to the User entity

### DIFF
--- a/config/install/field.field.user.user.field_identikey.yml
+++ b/config/install/field.field.user.user.field_identikey.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_identikey
+  module:
+    - user
+id: user.user.field_identikey
+field_name: field_identikey
+entity_type: user
+bundle: user
+label: IdentiKey
+description: 'CU Boulder IdentiKey used for SAML authentication sync.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string
+

--- a/config/install/field.storage.user.field_identikey.yml
+++ b/config/install/field.storage.user.field_identikey.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+id: user.field_identikey
+field_name: field_identikey
+entity_type: user
+type: string
+settings:
+  max_length: 255
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false
+

--- a/src/UserInviteHelperService.php
+++ b/src/UserInviteHelperService.php
@@ -319,17 +319,27 @@ class UserInviteHelperService {
           $existingUser->addRole($rid);
         }
       }
+      // Update identikey field if it exists and is empty.
+      if ($existingUser->hasField('field_identikey') && $existingUser->get('field_identikey')->isEmpty()) {
+        $existingUser->set('field_identikey', $invitedUser);
+      }
       $existingUser->save();
     }
     else {
-      User::create([
+      $user_data = [
         'name' => $invitedUser,
         'mail' => $invitedAddress,
         // This password isn't used to login, SSO is used instead.
         'pass' => 'password',
         'status' => 1,
         'roles' => $rids,
-      ])->enforceIsNew()->save();
+      ];
+      // Add identikey field if it exists.
+      $new_user = User::create($user_data);
+      if ($new_user->hasField('field_identikey')) {
+        $new_user->set('field_identikey', $invitedUser);
+      }
+      $new_user->enforceIsNew()->save();
     }
   }
 

--- a/ucb_user_invite.install
+++ b/ucb_user_invite.install
@@ -36,3 +36,54 @@ function ucb_user_invite_update_9501() {
   }
   $oldSettings->delete();
 }
+
+/**
+ * Adds the 'field_identikey' field to the User entity.
+ *
+ * Introduced in version 1.3 to support SAML authentication sync.
+ */
+function ucb_user_invite_update_9502() {
+  $field_name = 'field_identikey';
+  $entity_type = 'user';
+  $bundle = 'user';
+
+  // Check if field storage already exists.
+  $field_storage = \Drupal::entityTypeManager()
+    ->getStorage('field_storage_config')
+    ->load($entity_type . '.' . $field_name);
+
+  if (!$field_storage) {
+    // Create field storage.
+    $field_storage = \Drupal::entityTypeManager()
+      ->getStorage('field_storage_config')
+      ->create([
+        'field_name' => $field_name,
+        'entity_type' => $entity_type,
+        'type' => 'string',
+        'settings' => [
+          'max_length' => 255,
+        ],
+      ]);
+    $field_storage->save();
+  }
+
+  // Check if field instance already exists.
+  $field_config = \Drupal::entityTypeManager()
+    ->getStorage('field_config')
+    ->load($entity_type . '.' . $bundle . '.' . $field_name);
+
+  if (!$field_config) {
+    // Create field instance.
+    $field_config = \Drupal::entityTypeManager()
+      ->getStorage('field_config')
+      ->create([
+        'field_name' => $field_name,
+        'entity_type' => $entity_type,
+        'bundle' => $bundle,
+        'label' => t('IdentiKey'),
+        'description' => t('CU Boulder IdentiKey used for SAML authentication sync.'),
+        'required' => FALSE,
+      ]);
+    $field_config->save();
+  }
+}

--- a/ucb_user_invite.install
+++ b/ucb_user_invite.install
@@ -2,8 +2,9 @@
 
 /**
  * @file
- * Contains update hooks used by the CU Boulder User Invite module.
+ * Contains install and update hooks used by the CU Boulder User Invite module.
  */
+
 
 /**
  * Updates settings namespace.


### PR DESCRIPTION
Add `field_identikey` field to user configuration
Set that field based on `identikey` information provided in user invite

Update hook for adding `field_identikey` if the site is already live with the user invite module

Resolves #14 