### PR TITLE
#16 - Fixes link rendering incorrectly in Invite Email

### DIFF
--- a/ucb_user_invite.module
+++ b/ucb_user_invite.module
@@ -28,6 +28,17 @@ function ucb_user_invite_mail($key, &$message, $params) {
       '%login_link%' => Url::fromUserInput('/user/login', ['absolute' => TRUE])->toString(),
     ];
     $message['subject'] = $tokenService->replace(strtr($config->get($key . '_subject') ?? '', $variables), $tokens, $options);
-    $message['body'] = ['#markup' => $tokenService->replace(strtr($template, $variables), $tokens, $options)];
+    $rendered = $tokenService->replace(strtr($template, $variables), $tokens, $options);
+    // Convert only the login link to a plain URL, no <a> tags
+    $login_url = Url::fromUserInput('/user/login', ['absolute' => TRUE])->toString();
+    $rendered = preg_replace(
+      [
+        '#<a\s+[^>]*href=["\']' . preg_quote($login_url, '#') . '["\'][^>]*>.*?</a>#is',
+        '#<a\s+[^>]*href=["\']/user/login["\'][^>]*>.*?</a>#is',
+      ],
+      $login_url,
+      $rendered
+    );
+    $message['body'] = ['#markup' => $rendered];
   }
 }


### PR DESCRIPTION
Removes the wrapping `<a>` tag from the email body of a user invite, and instead lets the email client handle it

Resolves #16 